### PR TITLE
add markers for newlines

### DIFF
--- a/nbcelltesting/main.js
+++ b/nbcelltesting/main.js
@@ -262,7 +262,7 @@ define([
         diff.forEach(function(part) {
             var colorstyle = part.added ? 'added' : (part.removed ? 'removed' : 'common');
             modal_body.append($('<span/>').addClass('ct-diff-output-' + colorstyle)
-                              .html(part.value.replace(/\n/g, '<br/>')));
+                              .html(part.value.replace(/\n/g, '<span class="fa fa-level-down newline-marker"></span><br/>')));
         })
 
         var notebook = Jupyter.notebook;

--- a/nbcelltesting/nbcelltesting.css
+++ b/nbcelltesting/nbcelltesting.css
@@ -51,3 +51,6 @@
     background-color: #F5F5F5;
 }
 
+.newline-marker {
+    font-size: 0.6em;
+}


### PR DESCRIPTION
this is my suggestion for improving the problem mentioned in #22.

examples: 
- additional linebreak:
![image](https://cloud.githubusercontent.com/assets/11851593/22417696/cfc3578e-e6d5-11e6-872b-632aa8afd034.png)

- linebreak expected:
![image](https://cloud.githubusercontent.com/assets/11851593/22417723/e5fa0624-e6d5-11e6-88ac-5c1e20e3506e.png)

- no linebreak at all:
![image](https://cloud.githubusercontent.com/assets/11851593/22417732/f6767faa-e6d5-11e6-9258-f2f49154153d.png)

