### PR TITLE
recolor pending (info -> warning)

### DIFF
--- a/nbcelltesting/main.js
+++ b/nbcelltesting/main.js
@@ -203,8 +203,8 @@ define([
 
 
     var status = {'pending': {'text': '<span class="fa fa-spinner fa-spin"></span>',
-                              'style': 'info',
-                              'cls': 'label-info ct-status-pending',
+                              'style': 'warning',
+                              'cls': 'label-warning ct-status-pending',
                               'count': 0,
                               'title': 'Number of pending tests'},
                   'not_available': {'text': 'no output saved',


### PR DESCRIPTION
as discussed in #18, this is a branch where pending is recolored to yellow(ish).

example:
![peek 2017-01-30 10-28](https://cloud.githubusercontent.com/assets/11851593/22417998/4a17797e-e6d7-11e6-90f9-58f91490b729.gif)
